### PR TITLE
Submit business leads to Salesforce

### DIFF
--- a/src/css/get-in-touch.css
+++ b/src/css/get-in-touch.css
@@ -114,7 +114,6 @@
 }
 
 .thankyou {
-  display: none;
   font-size: 30px;
   text-align: center;
 }

--- a/src/got-in-touch.html
+++ b/src/got-in-touch.html
@@ -105,62 +105,7 @@
     </section>
 
     <section class="get-in-touch">
-      <form class="gform get-in-touch__form" action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
-        <input type=hidden name="oid" value="00D7F000005mScl">
-        <input type=hidden name="retURL" value="https://www.myopenpay.co.uk/got-in-touch">
-      
-        <div class="form-elements">
-          <div class="form__container">
-            <label class="form__label"
-              >First name *
-              <input
-                class="form__input"
-                type="text"
-                name="first_name"
-                required
-              />
-            </label>
-            <label class="form__label"
-              >Last name *
-              <input class="form__input" type="text" name="last_name" required />
-            </label>
-          </div>
-          <div class="form__container">
-            <label class="form__label"
-              >Email *
-              <input
-                class="form__input"
-                type="email"
-                name="email"
-                maxlength="254"
-                required
-              />
-            </label>
-            <label class="form__label"
-              >Phone *
-              <input class="form__input" type="text" name="phone" required />
-            </label>
-          </div>
-          <div class="form__container">
-            <label class="form__label"
-              >Company name *
-              <input class="form__input" type="text" name="company" required />
-            </label>
-            <label class="form__label form__label--select"
-              >Country
-              <select class="form__input form__input--select" name="country_code">
-                <option value="" disabled>Select a country</option>
-                <option value="GB" selected>United Kingdom</option>
-                <option value="AU">Australia</option>
-                <option value="US">United States</option>
-              </select>
-            </label>
-          </div>
-          <button class="form__submit" type="submit">
-            Submit
-          </button>
-        </div>
-      </form>
+        <div class="thankyou"><em>Thank you,</em> we'll be in touch.</div>
     </section>
 
     <div class="footer-wrap block-wap">
@@ -197,7 +142,7 @@
         </p>
         <p class="copyright__text">
           Openpay UK Limited is a company registered in England and Wales
-          (Company Number 11422596) with its registered office at 49 Greek St,
+          (Company Number 11422596) with it's registered office at 49 Greek St,
           London, United Kingdom, W1D4EG
         </p>
       </footer>


### PR DESCRIPTION
Remove some fields that are not necessary.
Submit to Salesforce instead of Google.
Salesforce doesn't seem to support CORS on lead capture, so added a new page to return to.